### PR TITLE
feat: 新增诊断历史记录功能（前后端完整实现）

### DIFF
--- a/backend/app/api/history_api.py
+++ b/backend/app/api/history_api.py
@@ -1,0 +1,137 @@
+"""
+诊断历史记录 CRUD API
+"""
+import json
+import logging
+import os
+import sqlite3
+import uuid
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models.schemas import HistoryCreateRequest, HistoryListItem, HistoryDetail
+
+router = APIRouter()
+logger = logging.getLogger("noterx.history")
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "data", "baseline.db")
+
+
+def _get_conn() -> sqlite3.Connection:
+    """获取 SQLite 连接（row_factory = Row）"""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+@router.post("/history", response_model=dict)
+async def create_history(req: HistoryCreateRequest):
+    """
+    保存一条诊断历史记录。
+    @param req - 包含 title, category, report(完整 DiagnoseResponse dict)
+    @returns {id: str} 新记录的 UUID
+    """
+    record_id = uuid.uuid4().hex
+    report = req.report
+    overall_score = report.get("overall_score", 0)
+    grade = report.get("grade", "")
+
+    conn = _get_conn()
+    try:
+        conn.execute(
+            """INSERT INTO diagnosis_history
+               (id, title, category, overall_score, grade, report_json)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (record_id, req.title, req.category, overall_score, grade, json.dumps(report, ensure_ascii=False)),
+        )
+        conn.commit()
+    except Exception as e:
+        logger.error("保存历史记录失败: %s", e)
+        raise HTTPException(500, "保存失败")
+    finally:
+        conn.close()
+
+    return {"id": record_id}
+
+
+@router.get("/history", response_model=list[HistoryListItem])
+async def list_history(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    """
+    获取历史记录列表（按时间倒序，不含完整报告 JSON）。
+    @param limit - 每页条数（默认 20，最大 100）
+    @param offset - 偏移量
+    """
+    conn = _get_conn()
+    try:
+        rows = conn.execute(
+            """SELECT id, title, category, overall_score, grade, created_at
+               FROM diagnosis_history
+               ORDER BY created_at DESC
+               LIMIT ? OFFSET ?""",
+            (limit, offset),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    return [
+        HistoryListItem(
+            id=r["id"],
+            title=r["title"],
+            category=r["category"],
+            overall_score=r["overall_score"] or 0,
+            grade=r["grade"] or "",
+            created_at=r["created_at"] or "",
+        )
+        for r in rows
+    ]
+
+
+@router.get("/history/{record_id}", response_model=HistoryDetail)
+async def get_history(record_id: str):
+    """
+    获取单条历史记录详情（含完整报告）。
+    @param record_id - UUID
+    """
+    conn = _get_conn()
+    try:
+        row = conn.execute(
+            """SELECT id, title, category, overall_score, grade, report_json, created_at
+               FROM diagnosis_history WHERE id = ?""",
+            (record_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if not row:
+        raise HTTPException(404, "记录不存在")
+
+    return HistoryDetail(
+        id=row["id"],
+        title=row["title"],
+        category=row["category"],
+        overall_score=row["overall_score"] or 0,
+        grade=row["grade"] or "",
+        created_at=row["created_at"] or "",
+        report=json.loads(row["report_json"]),
+    )
+
+
+@router.delete("/history/{record_id}")
+async def delete_history(record_id: str):
+    """
+    删除一条历史记录。
+    @param record_id - UUID
+    """
+    conn = _get_conn()
+    try:
+        cur = conn.execute("DELETE FROM diagnosis_history WHERE id = ?", (record_id,))
+        conn.commit()
+        if cur.rowcount == 0:
+            raise HTTPException(404, "记录不存在")
+    finally:
+        conn.close()
+
+    return {"ok": True}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -6,8 +6,10 @@ from fastapi import APIRouter
 from app.api.diagnose import router as diagnose_router
 from app.api.baseline_api import router as baseline_router
 from app.api.link_api import router as link_router
+from app.api.history_api import router as history_router
 
 router = APIRouter()
 router.include_router(diagnose_router, tags=["diagnose"])
 router.include_router(baseline_router, tags=["baseline"])
 router.include_router(link_router, tags=["link"])
+router.include_router(history_router, tags=["history"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,11 +2,46 @@
 NoteRx 后端入口
 """
 import logging
+import os
+import sqlite3
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes import router as api_router
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "baseline.db")
+
+
+def _ensure_history_table():
+    """启动时自动创建 diagnosis_history 表（如不存在）"""
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS diagnosis_history (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            category TEXT NOT NULL,
+            overall_score REAL,
+            grade TEXT,
+            report_json TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_history_created
+        ON diagnosis_history(created_at DESC)
+    """)
+    conn.commit()
+    conn.close()
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """应用生命周期：启动时自动建表"""
+    _ensure_history_table()
+    yield
 
 logging.basicConfig(
     level=logging.INFO,
@@ -17,6 +52,7 @@ app = FastAPI(
     title="NoteRx API",
     description="AI驱动的小红书笔记诊断平台",
     version="0.2.0",
+    lifespan=lifespan,
 )
 
 app.add_middleware(

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -3,6 +3,7 @@ Pydantic 请求 / 响应模型
 """
 from pydantic import BaseModel
 from typing import Optional
+from datetime import datetime
 
 
 class DiagnoseRequest(BaseModel):
@@ -63,3 +64,33 @@ class DiagnoseResponse(BaseModel):
     optimized_title: Optional[str] = None
     optimized_content: Optional[str] = None
     cover_direction: Optional[CoverDirection] = None
+
+
+# --------------- 历史记录 ---------------
+
+class HistoryCreateRequest(BaseModel):
+    """保存诊断历史"""
+    title: str
+    category: str
+    report: dict
+
+
+class HistoryListItem(BaseModel):
+    """历史列表项（不含完整报告）"""
+    id: str
+    title: str
+    category: str
+    overall_score: float
+    grade: str
+    created_at: str
+
+
+class HistoryDetail(BaseModel):
+    """历史详情（含完整报告）"""
+    id: str
+    title: str
+    category: str
+    overall_score: float
+    grade: str
+    created_at: str
+    report: dict

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import theme from "./theme";
 import Home from "./pages/Home";
 import Diagnosing from "./pages/Diagnosing";
 import Report from "./pages/Report";
+import History from "./pages/History";
 import ToastContainer from "./components/Toast";
 import ErrorBoundary from "./components/ErrorBoundary";
 import "./index.css";
@@ -21,6 +22,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/diagnosing" element={<Diagnosing />} />
             <Route path="/report" element={<Report />} />
+            <Route path="/history" element={<History />} />
           </Routes>
           <ToastContainer />
         </BrowserRouter>

--- a/frontend/src/pages/Diagnosing.tsx
+++ b/frontend/src/pages/Diagnosing.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Box, Card, CardContent, Typography } from "@mui/material";
-import { diagnoseNote } from "../utils/api";
+import { diagnoseNote, saveHistory } from "../utils/api";
+import type { DiagnoseResult } from "../utils/api";
 import { FALLBACK_REPORT } from "../utils/fallback";
 import DiagnoseAnimation from "../components/DiagnoseAnimation";
 
@@ -54,6 +55,11 @@ export default function Diagnosing() {
           coverImage: params.coverFile ?? undefined,
         });
         resultRef.current = { report: result, isFallback: false };
+        saveHistory({
+          title: params.title,
+          category: params.category,
+          report: result as DiagnoseResult,
+        }).catch((e) => console.warn("保存历史记录失败", e));
       } catch (err) {
         console.warn("API 不可用，使用 fallback 数据", err);
         resultRef.current = { report: FALLBACK_REPORT, isFallback: true };

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -1,0 +1,326 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Typography,
+  Button,
+  Card,
+  CardActionArea,
+  CardContent,
+  Stack,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import DeleteIcon from "@mui/icons-material/Delete";
+import HistoryIcon from "@mui/icons-material/History";
+import {
+  getHistoryList,
+  getHistoryDetail,
+  deleteHistory,
+} from "../utils/api";
+import type { HistoryListItem } from "../utils/api";
+
+const CATEGORY_LABEL: Record<string, string> = {
+  food: "美食",
+  fashion: "时尚",
+  tech: "科技",
+  travel: "旅行",
+  beauty: "美妆",
+  fitness: "健身",
+  life: "生活",
+};
+
+const GRADE_COLOR: Record<string, string> = {
+  S: "#10b981",
+  A: "#14b8a6",
+  B: "#3b82f6",
+  C: "#f59e0b",
+  D: "#ef4444",
+};
+
+/**
+ * 历史记录页
+ */
+export default function History() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState<HistoryListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [navigating, setNavigating] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<HistoryListItem | null>(null);
+
+  const fetchList = async () => {
+    setLoading(true);
+    try {
+      const list = await getHistoryList(50);
+      setItems(list);
+    } catch (e) {
+      console.error("获取历史记录失败", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchList();
+  }, []);
+
+  /** 点击卡片：加载完整报告后跳转 Report 页 */
+  const handleOpen = async (item: HistoryListItem) => {
+    setNavigating(item.id);
+    try {
+      const detail = await getHistoryDetail(item.id);
+      navigate("/report", {
+        state: {
+          report: detail.report,
+          params: { title: detail.title, category: detail.category },
+          isFallback: false,
+        },
+      });
+    } catch (e) {
+      console.error("获取报告详情失败", e);
+      setNavigating(null);
+    }
+  };
+
+  /** 确认删除 */
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteHistory(deleteTarget.id);
+      setItems((prev) => prev.filter((i) => i.id !== deleteTarget.id));
+    } catch (e) {
+      console.error("删除失败", e);
+    }
+    setDeleteTarget(null);
+  };
+
+  const formatTime = (ts: string) => {
+    if (!ts) return "";
+    const d = new Date(ts.includes("T") ? ts : ts.replace(" ", "T"));
+    return d.toLocaleString("zh-CN", {
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        background:
+          "linear-gradient(160deg, #ecfdf5 0%, #ffffff 50%, #f0fdfa 100%)",
+        pb: 10,
+      }}
+    >
+      {/* 顶栏 */}
+      <Box
+        sx={{
+          position: "sticky",
+          top: 0,
+          zIndex: 10,
+          bgcolor: "rgba(255,255,255,0.85)",
+          backdropFilter: "blur(12px)",
+          borderBottom: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Box
+          sx={{
+            maxWidth: 720,
+            mx: "auto",
+            px: 2,
+            py: 1.5,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Button
+            startIcon={<ArrowBackIcon />}
+            onClick={() => navigate("/")}
+            size="small"
+            color="inherit"
+          >
+            首页
+          </Button>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <HistoryIcon color="primary" />
+            <Typography sx={{ fontWeight: 700 }} color="primary">
+              诊断历史
+            </Typography>
+          </Box>
+          <Box sx={{ width: 64 }} />
+        </Box>
+      </Box>
+
+      <Box sx={{ maxWidth: 720, mx: "auto", px: 2, mt: 3 }}>
+        {loading ? (
+          <Box sx={{ textAlign: "center", py: 10 }}>
+            <CircularProgress color="primary" />
+            <Typography color="text.secondary" sx={{ mt: 2 }}>
+              加载中...
+            </Typography>
+          </Box>
+        ) : items.length === 0 ? (
+          <Box sx={{ textAlign: "center", py: 10 }}>
+            <Typography fontSize={48}>📋</Typography>
+            <Typography color="text.secondary" sx={{ mt: 1 }}>
+              暂无诊断记录
+            </Typography>
+            <Button
+              variant="contained"
+              sx={{ mt: 3 }}
+              onClick={() => navigate("/")}
+            >
+              去诊断一篇笔记
+            </Button>
+          </Box>
+        ) : (
+          <Stack spacing={2}>
+            {items.map((item) => (
+              <Card key={item.id} sx={{ position: "relative" }}>
+                <CardActionArea
+                  onClick={() => handleOpen(item)}
+                  disabled={navigating === item.id}
+                >
+                  <CardContent
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 2,
+                      pr: 7,
+                    }}
+                  >
+                    {/* 评分圆 */}
+                    <Box
+                      sx={{
+                        width: 56,
+                        height: 56,
+                        borderRadius: "50%",
+                        flexShrink: 0,
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        background: `linear-gradient(135deg, ${GRADE_COLOR[item.grade] || "#999"}22, ${GRADE_COLOR[item.grade] || "#999"}11)`,
+                        border: `2px solid ${GRADE_COLOR[item.grade] || "#ccc"}`,
+                      }}
+                    >
+                      <Typography
+                        sx={{
+                          fontWeight: 800,
+                          fontSize: 18,
+                          color: GRADE_COLOR[item.grade] || "#666",
+                          lineHeight: 1,
+                        }}
+                      >
+                        {Math.round(item.overall_score)}
+                      </Typography>
+                      <Typography
+                        sx={{
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: GRADE_COLOR[item.grade] || "#666",
+                          lineHeight: 1,
+                          mt: 0.2,
+                        }}
+                      >
+                        {item.grade}
+                      </Typography>
+                    </Box>
+
+                    {/* 文本区 */}
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography
+                        variant="subtitle1"
+                        fontWeight={600}
+                        sx={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {item.title}
+                      </Typography>
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1,
+                          mt: 0.5,
+                        }}
+                      >
+                        <Chip
+                          label={
+                            CATEGORY_LABEL[item.category] || item.category
+                          }
+                          size="small"
+                          variant="outlined"
+                          sx={{ height: 22, fontSize: 12 }}
+                        />
+                        <Typography variant="caption" color="text.secondary">
+                          {formatTime(item.created_at)}
+                        </Typography>
+                      </Box>
+                    </Box>
+
+                    {navigating === item.id && (
+                      <CircularProgress size={20} sx={{ ml: 1 }} />
+                    )}
+                  </CardContent>
+                </CardActionArea>
+
+                {/* 删除按钮 */}
+                <IconButton
+                  size="small"
+                  sx={{
+                    position: "absolute",
+                    right: 8,
+                    top: "50%",
+                    transform: "translateY(-50%)",
+                    color: "text.disabled",
+                    "&:hover": { color: "error.main" },
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setDeleteTarget(item);
+                  }}
+                >
+                  <DeleteIcon fontSize="small" />
+                </IconButton>
+              </Card>
+            ))}
+          </Stack>
+        )}
+      </Box>
+
+      {/* 删除确认对话框 */}
+      <Dialog
+        open={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+      >
+        <DialogTitle>删除记录</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            确定删除「{deleteTarget?.title}」的诊断记录吗？此操作不可恢复。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>取消</Button>
+          <Button onClick={handleDelete} color="error">
+            删除
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import {
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import LinkIcon from "@mui/icons-material/Link";
+import HistoryIcon from "@mui/icons-material/History";
 import UploadZone from "../components/UploadZone";
 import CategorySelector from "../components/CategorySelector";
 import { parseLink } from "../utils/api";
@@ -60,7 +61,16 @@ export default function Home() {
       }}
     >
       {/* Header */}
-      <Box sx={{ pt: 6, pb: 2, textAlign: "center" }}>
+      <Box sx={{ pt: 6, pb: 2, textAlign: "center", position: "relative" }}>
+        <Button
+          startIcon={<HistoryIcon />}
+          onClick={() => navigate("/history")}
+          size="small"
+          color="inherit"
+          sx={{ position: "absolute", right: 16, top: 24 }}
+        >
+          历史记录
+        </Button>
         <Box sx={{ display: "inline-flex", alignItems: "center", gap: 1, mb: 1 }}>
           <Typography fontSize={40}>💊</Typography>
           <Typography

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -4,6 +4,7 @@ import {
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import HistoryIcon from "@mui/icons-material/History";
 import type { DiagnoseResult } from "../utils/api";
 import ScoreCard from "../components/ScoreCard";
 import RadarChart from "../components/RadarChart";
@@ -73,7 +74,9 @@ export default function Report() {
             <Typography sx={{ fontSize: 20 }}>💊</Typography>
             <Typography sx={{ fontWeight: 700 }} color="primary">诊断报告</Typography>
           </Box>
-          <Box sx={{ width: 90 }} />
+          <Button startIcon={<HistoryIcon />} onClick={() => navigate("/history")} size="small" color="inherit">
+            历史
+          </Button>
         </Box>
       </Box>
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -113,4 +113,61 @@ export async function getBaseline(category: string) {
   return data;
 }
 
+// --------------- 历史记录 ---------------
+
+export interface HistoryListItem {
+  id: string;
+  title: string;
+  category: string;
+  overall_score: number;
+  grade: string;
+  created_at: string;
+}
+
+export interface HistoryDetail extends HistoryListItem {
+  report: DiagnoseResult;
+}
+
+/**
+ * @param params - title, category, report(完整 DiagnoseResult)
+ * @returns {id: string}
+ */
+export async function saveHistory(params: {
+  title: string;
+  category: string;
+  report: DiagnoseResult;
+}): Promise<{ id: string }> {
+  const { data } = await api.post<{ id: string }>("/history", params);
+  return data;
+}
+
+/**
+ * @param limit - 每页条数
+ * @param offset - 偏移量
+ */
+export async function getHistoryList(
+  limit = 20,
+  offset = 0
+): Promise<HistoryListItem[]> {
+  const { data } = await api.get<HistoryListItem[]>("/history", {
+    params: { limit, offset },
+  });
+  return data;
+}
+
+/**
+ * @param id - 记录 UUID
+ */
+export async function getHistoryDetail(id: string): Promise<HistoryDetail> {
+  const { data } = await api.get<HistoryDetail>(`/history/${id}`);
+  return data;
+}
+
+/**
+ * @param id - 记录 UUID
+ */
+export async function deleteHistory(id: string): Promise<void> {
+  await api.delete(`/history/${id}`);
+}
+
 export default api;

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -50,6 +50,23 @@ def init_database():
     """)
 
     cursor.execute("""
+        CREATE TABLE IF NOT EXISTS diagnosis_history (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            category TEXT NOT NULL,
+            overall_score REAL,
+            grade TEXT,
+            report_json TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_history_created
+        ON diagnosis_history(created_at DESC)
+    """)
+
+    cursor.execute("""
         CREATE INDEX IF NOT EXISTS idx_notes_category ON notes(category)
     """)
     cursor.execute("""


### PR DESCRIPTION
- 后端：SQLite diagnosis_history 表 + 自动建表（lifespan）
- 后端：history_api.py 提供 CRUD 4 个端点（POST/GET/GET/:id/DELETE）
- 前端：Diagnosing 诊断成功后自动保存历史
- 前端：新增 History 页面（卡片列表、删除确认、空状态）
- 前端：Home 和 Report 页顶栏增加历史记录导航入口

Made-with: Cursor