### PR TITLE
fix: 历史查看入口增强并修正前端代理端口

### DIFF
--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -15,6 +15,7 @@ import {
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import InboxOutlinedIcon from "@mui/icons-material/InboxOutlined";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { motion } from "framer-motion";
 import {
   getHistoryList,
@@ -268,6 +269,28 @@ export default function History() {
                     {navigating === item.id && (
                       <CircularProgress size={16} sx={{ color: "#999" }} />
                     )}
+
+                    <Button
+                      size="small"
+                      variant="text"
+                      startIcon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                      sx={{
+                        color: "#666",
+                        minWidth: "unset",
+                        px: 0.5,
+                        textTransform: "none",
+                        fontSize: 12,
+                        flexShrink: 0,
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (!navigating) {
+                          handleOpen(item);
+                        }
+                      }}
+                    >
+                      查看结果
+                    </Button>
 
                     {/* 删除按钮 */}
                     <IconButton

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8001',
+        target: 'http://localhost:8000',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
- 历史记录每条新增“查看结果”按钮，支持显式进入报告详情
- 将 Vite /api 代理目标改为 8000，避免诊断请求回退到演示数据

Made-with: Cursor