### PR TITLE
fix: sync env example video upload settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,25 +80,9 @@ FRONTEND_PORT=5173
 # MAX_VIDEO_UPLOAD_MB=300
 
 # === 视频理解（MiMo video_url：整段视频，非仅抽帧）===
-# 模型会从公网拉取「签名后的临时视频 URL」，localhost 直连无法被云端访问。
-#
-# 上线二选一（可同时使用，优先读 MIMO_VIDEO_PUBLIC_BASE_URL）：
-# 1) 显式写死对外的 API 根地址（推荐，与是否经反代无关）：
-#    MIMO_VIDEO_PUBLIC_BASE_URL=https://api.yourdomain.com
-# 2) 在 Nginx / Caddy 等反代上为后端注入转发头，由服务端拼出公网 URL：
-#    proxy_set_header X-Forwarded-Proto $scheme;
-#    proxy_set_header X-Forwarded-Host $host;
-#    此时可不填 MIMO_VIDEO_PUBLIC_BASE_URL。
-#
-# 若两者皆无且直连 127.0.0.1，则仅走「抽帧 + 图像理解」，不做整段视频理解。
-# 可通过 /api/video-public-url-health 查看当前环境判定结果（ok/reason/source/base_url）。
-MIMO_VIDEO_PUBLIC_BASE_URL=
-
-# 临时视频链接 HMAC 密钥（生产环境务必改为长随机串）
-TEMP_VIDEO_SIGNING_KEY=change-me-to-a-long-random-secret
-
-# 临时视频链接有效期（秒，默认 900 = 15 分钟）
-TEMP_VIDEO_TTL_SECONDS=900
+# CDN 上传接口配置：服务端将视频上传到 CDN 后，把公网 URL 交给 MiMo 拉取。
+CDN_UPLOAD_URL=
+CDN_UPLOAD_FIELD=file
 
 # 可选：临时视频落盘目录（默认 backend/data/temp_videos）
 # TEMP_VIDEO_DIR=backend/data/temp_videos


### PR DESCRIPTION
## Summary
- Sync `.env.example` video upload variables with the current `.env` template shape.
- Replace stale temporary-video public URL settings with `CDN_UPLOAD_URL` and `CDN_UPLOAD_FIELD`.

Closes #83

## Test plan
- [x] Verified `.env.example` contains `CDN_UPLOAD_URL` and `CDN_UPLOAD_FIELD`.
- [x] Verified stale `MIMO_VIDEO_PUBLIC_BASE_URL`, `TEMP_VIDEO_SIGNING_KEY`, and `TEMP_VIDEO_TTL_SECONDS` active entries are removed.